### PR TITLE
Make preprocessing command line reference included example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To train the network you need a lot of SMILES strings. The `preprocess.py` scrip
 
 Example:
 
-`python preprocess.py data/dataset.h5 data/processed.h5`
+`python preprocess.py data/smiles_50k.h5 data/processed.h5`
 
 ## Training the network
 


### PR DESCRIPTION
This makes it easier to copy-paste the example command line directly.
