### PR TITLE
fix Lambda layer in autoencoder to work with Theano

### DIFF
--- a/autoencoder/model.py
+++ b/autoencoder/model.py
@@ -34,7 +34,7 @@ class MoleculeVAE():
             epsilon = K.random_normal(shape=(batch_size, latent_rep_size), mean=0., std=epsilon_std)
             return z_mean + K.exp(z_log_var / 2) * epsilon
 
-        z = Lambda(sampling)([z_mean, z_log_var])
+        z = Lambda(sampling, output_shape=(latent_rep_size,))([z_mean, z_log_var])
 
         h = Dense(latent_rep_size, name='latent_input', activation = 'relu')(z)
         h = RepeatVector(max_length)(h)

--- a/preprocess.py
+++ b/preprocess.py
@@ -40,7 +40,8 @@ def main():
 
     del data
 
-    train_idx, test_idx = train_test_split(xrange(structures.shape[0]), test_size = 0.20)
+    train_idx, test_idx = map(np.array,
+                              train_test_split(structures.index, test_size = 0.20))
 
     charset = list(reduce(lambda x, y: set(y) | x, structures, set()))
 

--- a/preprocess.py
+++ b/preprocess.py
@@ -23,6 +23,14 @@ def get_arguments():
                         PROPERTY_COL_NAME)
     return parser.parse_args()
 
+def chunk_iterator(dataset, chunk_size=1000):
+    chunk_indices = np.array_split(np.arange(len(dataset)),
+                                    len(dataset)/chunk_size)
+    for chunk_ixs in chunk_indices:
+        chunk = dataset[chunk_ixs]
+        yield (chunk_ixs, chunk)
+    raise StopIteration
+
 def main():
     args = get_arguments()
     data = pandas.read_hdf(args.infile, 'table')
@@ -44,16 +52,30 @@ def main():
 
     charset = list(reduce(lambda x, y: set(y) | x, structures, set()))
 
-    one_hot_encoded = np.array(
-        map(lambda row:
-            map(lambda x: one_hot_array(x, len(charset)),
-                one_hot_index(row, charset)),
-            structures))
+    one_hot_encoded_fn = lambda row: map(lambda x: one_hot_array(x, len(charset)),
+                                                one_hot_index(row, charset))
 
     h5f = h5py.File(args.outfile, 'w')
     h5f.create_dataset('charset', data = charset)
-    h5f.create_dataset('data_train', data = one_hot_encoded[train_idx])
-    h5f.create_dataset('data_test', data = one_hot_encoded[test_idx])
+
+    def create_chunk_dataset(h5file, dataset_name, dataset, dataset_shape,
+                             chunk_size=1000, apply_fn=None):
+        new_data = h5file.create_dataset(dataset_name, dataset_shape,
+                                         chunks=tuple([chunk_size]+list(dataset_shape[1:])))
+        for (chunk_ixs, chunk) in chunk_iterator(dataset):
+            if not apply_fn:
+                new_data[chunk_ixs, ...] = chunk
+            else:
+                new_data[chunk_ixs, ...] = apply_fn(chunk)
+
+    create_chunk_dataset(h5f, 'data_train', train_idx,
+                         (len(train_idx), 120, len(charset)),
+                         apply_fn=lambda ch: np.array(map(one_hot_encoded_fn,
+                                                          structures[ch])))
+    create_chunk_dataset(h5f, 'data_test', test_idx,
+                         (len(test_idx), 120, len(charset)),
+                         apply_fn=lambda ch: np.array(map(one_hot_encoded_fn,
+                                                          structures[ch])))
 
     if args.property_column:
         h5f.create_dataset('property_train', data = properties[train_idx])

--- a/sample.py
+++ b/sample.py
@@ -19,6 +19,8 @@ LATENT_DIM = 292
 def get_arguments():
     parser = argparse.ArgumentParser(description='Molecular autoencoder network')
     parser.add_argument('model', type=str, help='Trained Keras model to use.')
+    parser.add_argument('input_data', type=str,
+                        help='h5 file to sample from as input to model.')
     parser.add_argument('--latent_dim', type=int, metavar='N', default=LATENT_DIM,
                         help='Dimensionality of the latent representation.')
     return parser.parse_args()
@@ -27,7 +29,7 @@ def main():
     args = get_arguments()
     model = MoleculeVAE()
     
-    data, charset = load_dataset('data/all_smiles_120_one_hot.h5', split = False)
+    data, charset = load_dataset(args.input_data, split = False)
     
     if os.path.isfile(args.model):
         model.load(charset, args.model, latent_rep_size = args.latent_dim)


### PR DESCRIPTION
When using the Theano backend, the `Lambda` layer is not compiled, and the following error is output:

```The `get_output_shape_for` method of layer "lambda_1"" should return one shape tuple per output tensor of the layer. Found: [(None, 292), (None, 292)]```

This can be fixed just by specifying the `output_shape` in the call to `Lambda`, a la [the keras example here](https://github.com/fchollet/keras/blob/master/examples/variational_autoencoder.py#L34).