### PR TITLE
fix Lambda layer in autoencoder to work with Theano, correct branch

### DIFF
--- a/autoencoder/model.py
+++ b/autoencoder/model.py
@@ -34,7 +34,7 @@ class MoleculeVAE():
             epsilon = K.random_normal(shape=(batch_size, latent_rep_size), mean=0., std=epsilon_std)
             return z_mean + K.exp(z_log_var / 2) * epsilon
 
-        z = Lambda(sampling)([z_mean, z_log_var])
+        z = Lambda(sampling, output_shape=(latent_rep_size,))([z_mean, z_log_var])
 
         h = Dense(latent_rep_size, name='latent_input', activation = 'relu')(z)
         h = RepeatVector(max_length)(h)


### PR DESCRIPTION
When using the Theano backend, the `Lambda` layer is not compiled, and the following error is output:

```The `get_output_shape_for` method of layer "lambda_1"" should return one shape tuple per output tensor of the layer. Found: [(None, 292), (None, 292)]```

This can be fixed just by specifying the `output_shape` in the call to `Lambda`, a la [the keras example here](https://github.com/fchollet/keras/blob/master/examples/variational_autoencoder.py#L34).

#12 