### PR TITLE
sample: added --smiles and --save_json options

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -5,6 +5,7 @@ import os
 import h5py
 import numpy as np
 import sys
+import json
 
 from autoencoder.model import MoleculeVAE
 from autoencoder.utils import one_hot_array, one_hot_index, from_one_hot_array, \
@@ -23,11 +24,25 @@ def get_arguments():
     parser.add_argument('data', type=str, help='File of latent representation tensors for decoding.')
     parser.add_argument('model', type=str, help='Trained Keras model to use.')
     parser.add_argument('--save_h5', type=str, help='Name of a file to write HDF5 output to.')
+    parser.add_argument('--save_json', type=str, help='Name of a file to write json output to.')
     parser.add_argument('--target', type=str, default=TARGET,
                         help='What model to sample from: autoencoder, encoder, decoder.')
+    parser.add_argument('--smiles', type=str, default=None,
+                        help='A text file of smiles strings.')
     parser.add_argument('--latent_dim', type=int, metavar='N', default=LATENT_DIM,
                         help='Dimensionality of the latent representation.')
     return parser.parse_args()
+
+def encoded_to_string(encoded, charset):
+    return decode_smiles_from_indexes(map(from_one_hot_array, encoded), charset)
+
+def one_hot_encoded(string, charset):
+    return map(lambda x: one_hot_array(x, len(charset)), one_hot_index(string, charset))
+
+def string_to_encoded(string, charset):
+    padded = string.ljust(120)
+    encoded = one_hot_encoded(padded, list(charset))
+    return np.array(encoded)
 
 def read_latent_data(filename):
     h5f = h5py.File(filename, 'r')
@@ -68,6 +83,13 @@ def encoder(args, model):
     latent_dim = args.latent_dim
     data, charset = load_dataset(args.data, split = False)
 
+    if args.smiles is not None:
+        # replace data with data from file
+        with open(args.smiles) as f:
+            lines = f.readlines()
+        data = map(lambda x:string_to_encoded(x.rstrip(), charset), lines)
+        data = np.array(data)
+
     if os.path.isfile(args.model):
         model.load(charset, args.model, latent_rep_size = latent_dim)
     else:
@@ -79,6 +101,9 @@ def encoder(args, model):
         h5f.create_dataset('charset', data = charset)
         h5f.create_dataset('latent_vectors', data = x_latent)
         h5f.close()
+    elif args.save_json:
+        with open(args.save_json, 'w') as outfile:
+            json.dump(x_latent.tolist(), outfile)
     else:
         np.savetxt(sys.stdout, x_latent, delimiter = '\t')
 


### PR DESCRIPTION
--smiles can be used to encode smiles strings that are not
in the dataset. The dataset is still used to do the charset
one-hot encoding correctly.

--save_json was also added as an alternate output format