### PR TITLE
use https rather than git:// in requirement.txt

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -4,7 +4,7 @@ import h5py
 import numpy as np
 from autoencoder.utils import one_hot_array, one_hot_index
 
-from sklearn.cross_validation import train_test_split
+from sklearn.model_selection import train_test_split
 
 MAX_NUM_ROWS = 500000
 SMILES_COL_NAME = 'structure'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ scipy
 scikit-learn==0.18.0
 https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow-0.11.0rc1-cp27-none-linux_x86_64.whl
 h5py==2.6.0
--e git+git@github.com:fchollet/keras.git#egg=keras
+-e git+https://github.com/fchollet/keras.git#egg=keras
 matplotlib
 pandas
 tables


### PR DESCRIPTION
Use the HTTPS URL instead of the SSH/git URL to avoid having to deal with SSH keys. This is [GitHub's recommended method](https://help.github.com/articles/set-up-git/). This avoid the problem "Permission denied (publickey)" may happen  when use `pip -r requirements.txt` to install.